### PR TITLE
Fix url for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First things first, intall the `watchdog` module with `pip` through the followin
 
 Then clone the repository wherever you want and add it to your path: 
 
-    $ git clone git@github.com:dloureiro/pandoc-watch.git
+    $ git clone https://github.com/dloureiro/pandoc-watch.git
     $ export PATH=$(pwd):$PATH
 
 Simple as that!


### PR DESCRIPTION
I don't know why, but `git@github.com:dloureiro/pandoc-watch.git` was giving me errors when I tried to clone, but `https://github.com/dloureiro/pandoc-watch.git` works fine.
